### PR TITLE
Added Rounded #s for Debt Payments

### DIFF
--- a/src/Calculators/DebtAmortizator.php
+++ b/src/Calculators/DebtAmortizator.php
@@ -48,9 +48,9 @@ namespace FinanCalc\Calculators {
                     "days" => "debtLengthInDays"
                 ],
             "debtSingleRepayment",
-            "debtSingleRepayment_Rounded",
+            "debtSingleRepaymentRounded",
             "debtRepayments" => "debtRepaymentsAsArrays",
-            "debtRepayments_Rounded" => "debtRepaymentsAsArrays_Rounded"
+            "debtRepaymentsRounded" => "debtRepaymentsAsArraysRounded"
         ];
 
         /**
@@ -294,10 +294,10 @@ namespace FinanCalc\Calculators {
         /**
          * @return string [Value of a single debt repayment instance as a string]
          */
-        public function getDebtSingleRepayment_Rounded() {
+        public function getDebtSingleRepaymentRounded() {
             // single repayment 'K = PV/((1-v^n)/i)'
-            return MathFuncs::round_up(
-            	MathFuncs::div(
+            return MathFuncs::roundUp(
+                MathFuncs::div(
                 $this->debtPrincipal,
                 MathFuncs::div(
                     MathFuncs::sub(
@@ -341,30 +341,30 @@ namespace FinanCalc\Calculators {
 				 /**
          * @return array
          */
-        public function getDebtRepaymentsAsArrays_Rounded()
+        public function getDebtRepaymentsAsArraysRounded()
         {
             $repayments = array();
             $i = 1;
             $balance = $this->debtPrincipal;            
             foreach ($this->debtRepayments as $repayment) {
-          			if($balance > $repayment->getTotalAmount()) {      
-										$totalAmount = MathFuncs::round_up($repayment->getTotalAmount(), 2);
-										$interestAmount = MathFuncs::round($repayment->getInterestAmount(), 2);
-										$principalAmount = MathFuncs::round($totalAmount - $interestAmount, 2);
-								}
-								else {
-										$interestAmount = MathFuncs::round($repayment->getInterestAmount(), 2);
-										$totalAmount = MathFuncs::round(MathFuncs::add($balance, $interestAmount), 2);
-										$principalAmount = MathFuncs::round($balance, 2);
-								}
-            		
-            		$beginningBalance = $balance;
-            		$endingBalance = MathFuncs::sub($balance, $principalAmount);
-            		$balance = MathFuncs::sub($balance, $principalAmount);
-            		
+                if($balance > $repayment->getTotalAmount()) {      
+                    $totalAmount = MathFuncs::roundUp($repayment->getTotalAmount(), 2);
+                    $interestAmount = MathFuncs::round($repayment->getInterestAmount(), 2);
+                    $principalAmount = MathFuncs::round($totalAmount - $interestAmount, 2);
+                }
+                else {
+                    $interestAmount = MathFuncs::round($repayment->getInterestAmount(), 2);
+                    $totalAmount = MathFuncs::round(MathFuncs::add($balance, $interestAmount), 2);
+                    $principalAmount = MathFuncs::round($balance, 2);
+                }
+
+                $beginningBalance = $balance;
+                $endingBalance = MathFuncs::sub($balance, $principalAmount);
+                $balance = MathFuncs::sub($balance, $principalAmount);
+
                 $repayments[$i++] = [
-                		"beginningBalance" => MathFuncs::round($beginningBalance, 2),
-                		"totalAmount" => $totalAmount,
+                    "beginningBalance" => MathFuncs::round($beginningBalance, 2),
+                    "totalAmount" => $totalAmount,
                     "principalAmount" => $principalAmount,
                     "interestAmount" => $interestAmount,
                     "endingBalance" => MathFuncs::round($endingBalance, 2)

--- a/src/Utils/MathFuncs.php
+++ b/src/Utils/MathFuncs.php
@@ -79,5 +79,25 @@ namespace FinanCalc\Utils {
         {
             return (string)number_format((float)$roundedNumber, $precision);
         }
+        
+         /**
+         * @param $roundedNumber
+         * @param $precision
+         * @return string
+         */
+        public static function round_up($roundedNumber, $precision = 2) 
+        {
+            return (string)ceil((float)$roundedNumber * pow(10, $precision)) / pow(10, $precision);
+        }
+        
+        /**
+         * @param $roundedNumber
+         * @param $precision
+         * @return string
+         */
+        public static function round_down($roundedNumber, $precision = 2) 
+        {
+            return (string)floor((float)$roundedNumber * pow(10, $precision)) / pow(10, $precision);
+        }
     }
 }

--- a/src/Utils/MathFuncs.php
+++ b/src/Utils/MathFuncs.php
@@ -85,7 +85,7 @@ namespace FinanCalc\Utils {
          * @param $precision
          * @return string
          */
-        public static function round_up($roundedNumber, $precision = 2) 
+        public static function roundUp($roundedNumber, $precision = 2) 
         {
             return (string)ceil((float)$roundedNumber * pow(10, $precision)) / pow(10, $precision);
         }
@@ -95,7 +95,7 @@ namespace FinanCalc\Utils {
          * @param $precision
          * @return string
          */
-        public static function round_down($roundedNumber, $precision = 2) 
+        public static function roundDown($roundedNumber, $precision = 2) 
         {
             return (string)floor((float)$roundedNumber * pow(10, $precision)) / pow(10, $precision);
         }

--- a/tests/DebtAmortizatorTest.php
+++ b/tests/DebtAmortizatorTest.php
@@ -281,6 +281,33 @@ class DebtAmortizatorTest extends PHPUnit_Framework_TestCase
         $this->assertEquals("8686.63", round($repayments[6]["principalAmount"], 2));
         $this->assertEquals("1042.4", round($repayments[6]["interestAmount"], 2));
         $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repayments[6]["totalAmount"], 2));
+        
+        $repaymentsRounded = $resultArray["debtRepaymentsRounded"];
+
+        $INDIVIDUAL_REPAYMENT = "9729.03";
+        $this->assertEquals("4929.03", round($repaymentsRounded[1]["principalAmount"], 2));
+        $this->assertEquals("4800.00", round($repaymentsRounded[1]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[1]["totalAmount"], 2));
+
+        $this->assertEquals("5520.51", round($repaymentsRounded[2]["principalAmount"], 2));
+        $this->assertEquals("4208.52", round($repaymentsRounded[2]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[2]["totalAmount"], 2));
+
+        $this->assertEquals("6182.97", round($repaymentsRounded[3]["principalAmount"], 2));
+        $this->assertEquals("3546.06", round($repaymentsRounded[3]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[3]["totalAmount"], 2));
+
+        $this->assertEquals("6924.93", round($repaymentsRounded[4]["principalAmount"], 2));
+        $this->assertEquals("2804.10", round($repaymentsRounded[4]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[4]["totalAmount"], 2));
+
+        $this->assertEquals("7755.92", round($repaymentsRounded[5]["principalAmount"], 2));
+        $this->assertEquals("1973.11", round($repaymentsRounded[5]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[5]["totalAmount"], 2));
+
+        $this->assertEquals("8686.63", round($repaymentsRounded[6]["principalAmount"], 2));
+        $this->assertEquals("1042.4", round($repaymentsRounded[6]["interestAmount"], 2));
+        $this->assertEquals($INDIVIDUAL_REPAYMENT, round($repaymentsRounded[6]["totalAmount"], 2));
     }
 
     /**

--- a/tests/MathFuncsTest.php
+++ b/tests/MathFuncsTest.php
@@ -42,4 +42,14 @@ class MathFuncsTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals("3.68", MathFuncs::round(3.675624));
     }
+    
+    public function testRoundUp()
+    {
+        $this->assertEquals("3.69", MathFuncs::round(3.675624));
+    }
+    
+    public function testRoundDown()
+    {
+        $this->assertEquals("3.67", MathFuncs::round(3.675624));
+    }
 }


### PR DESCRIPTION
added round_up & round_down to mathfuncs,
added debtSingleRepayment_Rounded & debtRepayments_Rounded to
DebtAmortizator… added beginning and ending balance to test round math
worked out. Decided to keep since I think it would be nice have in
there. Rounding logic was decided on when testing against a couple
official amortization schedules
